### PR TITLE
Spotify Player: track control, track status, layout fixed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import configureStore from './redux/configureStore';
 
-import SpotifyPlayer from './components/SpotifyPlayer';
+//import SpotifyPlayer from './components/SpotifyPlayer';
+import TrackPlayControl from './components/SpotifyPlayer/TrackPlayControl';
 
 export const store = configureStore();
 class App extends Component {
@@ -10,7 +11,7 @@ class App extends Component {
     return (
       <Provider store={store}>
         <div>
-          <SpotifyPlayer />
+          <TrackPlayControl />
         </div>
       </Provider>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import configureStore from './redux/configureStore';
 
-import SongTrackCard from './components/SongTrackCard';
+import SpotifyPlayer from './components/SpotifyPlayer';
 
 export const store = configureStore();
 class App extends Component {
@@ -10,7 +10,7 @@ class App extends Component {
     return (
       <Provider store={store}>
         <div>
-          <SongTrackCard />;
+          <SpotifyPlayer />
         </div>
       </Provider>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import configureStore from './redux/configureStore';
 
-//import SpotifyPlayer from './components/SpotifyPlayer';
-import TrackPlayControl from './components/SpotifyPlayer/TrackPlayControl';
+import SpotifyPlayer from './components/SpotifyPlayer';
 
 export const store = configureStore();
 class App extends Component {
@@ -11,7 +10,7 @@ class App extends Component {
     return (
       <Provider store={store}>
         <div>
-          <TrackPlayControl />
+          <SpotifyPlayer />
         </div>
       </Provider>
     );

--- a/src/components/SpotifyPlayer/TrackList/DurationInfo.js
+++ b/src/components/SpotifyPlayer/TrackList/DurationInfo.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropType from 'prop-types';
+
+import Text from './Text';
+
+const getMinsAndSecs = (duration) => {
+  const mins = Math.floor(duration / 1000 / 60);
+  const secs = Math.ceil((duration / 1000) - (mins * 60));
+  return { mins, secs };
+};
+
+export default function DurationInfo({ duration, isPlaying }) {
+  const { mins, secs } = getMinsAndSecs(duration);
+  return (
+    <Text
+      isPlaying={isPlaying}
+      activecolor="#42f46e"
+      inactivecolor="grey"
+      floated="right"
+    >
+      {mins}:{secs}
+    </Text>
+  );
+}
+
+DurationInfo.propTypes = {
+  duration: PropType.number.isRequired,
+  isPlaying: PropType.bool.isRequired,
+};

--- a/src/components/SpotifyPlayer/TrackList/DurationInfo.js
+++ b/src/components/SpotifyPlayer/TrackList/DurationInfo.js
@@ -1,16 +1,13 @@
 import React from 'react';
 import PropType from 'prop-types';
+import moment from 'moment';
 
 import Text from './Text';
 
-const getMinsAndSecs = (duration) => {
-  const mins = Math.floor(duration / 1000 / 60);
-  const secs = Math.ceil((duration / 1000) - (mins * 60));
-  return { mins, secs };
-};
+/* eslint-disable no-underscore-dangle */
+const getTimeDisplay = time => moment(moment.duration(time)._data).format('mm:ss');
 
 export default function DurationInfo({ duration, isPlaying }) {
-  const { mins, secs } = getMinsAndSecs(duration);
   return (
     <Text
       isPlaying={isPlaying}
@@ -18,12 +15,17 @@ export default function DurationInfo({ duration, isPlaying }) {
       inactivecolor="grey"
       floated="right"
     >
-      {mins}:{secs}
+      {getTimeDisplay(duration)}
     </Text>
   );
 }
 
 DurationInfo.propTypes = {
-  duration: PropType.number.isRequired,
-  isPlaying: PropType.bool.isRequired,
+  duration: PropType.number,
+  isPlaying: PropType.bool,
+};
+
+DurationInfo.defaultProps = {
+  duration: 0,
+  isPlaying: false,
 };

--- a/src/components/SpotifyPlayer/TrackList/PlayStatus.js
+++ b/src/components/SpotifyPlayer/TrackList/PlayStatus.js
@@ -25,5 +25,9 @@ export default function PlayStatus({ index, isPlaying }) {
 
 PlayStatus.propTypes = {
   index: PropType.number.isRequired,
-  isPlaying: PropType.bool.isRequired,
+  isPlaying: PropType.bool,
+};
+
+PlayStatus.defaultProps = {
+  isPlaying: false,
 };

--- a/src/components/SpotifyPlayer/TrackList/PlayStatus.js
+++ b/src/components/SpotifyPlayer/TrackList/PlayStatus.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropType from 'prop-types';
+import { List } from 'semantic-ui-react';
+
+import Text from './Text';
+
+export default function PlayStatus({ index, isPlaying }) {
+  if (isPlaying) {
+    return (
+      <List.Icon
+        name="volume up"
+        verticalAlign="middle"
+        color="green"
+      />);
+  }
+  return (
+    <Text
+      inactivecolor="grey"
+      floated="left"
+    >
+      {index + 1}
+    </Text>
+  );
+}
+
+PlayStatus.propTypes = {
+  index: PropType.number.isRequired,
+  isPlaying: PropType.bool.isRequired,
+};

--- a/src/components/SpotifyPlayer/TrackList/Text.js
+++ b/src/components/SpotifyPlayer/TrackList/Text.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import styled from 'styled-components';
+import { List } from 'semantic-ui-react';
+
+const Text = styled(({ isPlaying, ...props }) => <List.Content {...props} />)`
+  color: ${({ isPlaying, activecolor, inactivecolor }) => (isPlaying ? activecolor : inactivecolor)};
+  font-weight: ${({ isPlaying }) => (isPlaying ? 'bold' : 'normal')};
+`;
+
+export default Text;

--- a/src/components/SpotifyPlayer/TrackList/Text.js
+++ b/src/components/SpotifyPlayer/TrackList/Text.js
@@ -4,7 +4,6 @@ import { List } from 'semantic-ui-react';
 
 const Text = styled(({ isPlaying, ...props }) => <List.Content {...props} />)`
   color: ${({ isPlaying, activecolor, inactivecolor }) => (isPlaying ? activecolor : inactivecolor)};
-  font-weight: ${({ isPlaying }) => (isPlaying ? 'bold' : 'normal')};
 `;
 
 export default Text;

--- a/src/components/SpotifyPlayer/TrackList/index.js
+++ b/src/components/SpotifyPlayer/TrackList/index.js
@@ -19,16 +19,16 @@ export default class extends React.Component {
     return (
       <List divided inverted relaxed style={{ height: 100, overflowY: 'scroll' }}>
         {
-          tracks.map(({ name, duration, isPlaying }, index) => (
-            <List.Item key={name}>
-              <DurationInfo isPlaying={isPlaying} duration={duration} />
+          tracks.map(({ songName, durationMs, isPlaying }, index) => (
+            <List.Item key={songName}>
+              <DurationInfo isPlaying={isPlaying} duration={durationMs} />
               <PlayStatus isPlaying={isPlaying} index={index} />
               <Text
                 isPlaying={isPlaying}
                 activecolor="#42f46e"
                 inactivecolor="grey"
               >
-                {name}
+                {songName}
               </Text>
             </List.Item>))
         }

--- a/src/components/SpotifyPlayer/TrackList/index.js
+++ b/src/components/SpotifyPlayer/TrackList/index.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  List,
-  Segment,
-} from 'semantic-ui-react';
+import { List } from 'semantic-ui-react';
 import DurationInfo from './DurationInfo';
 import PlayStatus from './PlayStatus';
 import Text from './Text';
@@ -20,24 +17,22 @@ export default class extends React.Component {
   render() {
     const { tracks } = this.props;
     return (
-      <Segment inverted>
-        <List divided inverted relaxed style={{ height: 100, overflowY: 'scroll' }}>
-          {
-            tracks.map(({ name, duration, isPlaying }, index) => (
-              <List.Item key={name}>
-                <DurationInfo isPlaying={isPlaying} duration={duration} />
-                <PlayStatus isPlaying={isPlaying} index={index} />
-                <Text
-                  isPlaying={isPlaying}
-                  activecolor="#42f46e"
-                  inactivecolor="grey"
-                >
-                  {name}
-                </Text>
-              </List.Item>))
-          }
-        </List>
-      </Segment>
+      <List divided inverted relaxed style={{ height: 100, overflowY: 'scroll' }}>
+        {
+          tracks.map(({ name, duration, isPlaying }, index) => (
+            <List.Item key={name}>
+              <DurationInfo isPlaying={isPlaying} duration={duration} />
+              <PlayStatus isPlaying={isPlaying} index={index} />
+              <Text
+                isPlaying={isPlaying}
+                activecolor="#42f46e"
+                inactivecolor="grey"
+              >
+                {name}
+              </Text>
+            </List.Item>))
+        }
+      </List>
     );
   }
 }

--- a/src/components/SpotifyPlayer/TrackList/index.js
+++ b/src/components/SpotifyPlayer/TrackList/index.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  List,
+  Segment,
+} from 'semantic-ui-react';
+import DurationInfo from './DurationInfo';
+import PlayStatus from './PlayStatus';
+import Text from './Text';
+
+export default class extends React.Component {
+  static propTypes = {
+    tracks: PropTypes.array.isRequired,
+  }
+
+  static defaultProps = {
+    tracks: [],
+  }
+
+  render() {
+    const { tracks } = this.props;
+    return (
+      <Segment inverted>
+        <List divided inverted relaxed style={{ height: 100, overflowY: 'scroll' }}>
+          {
+            tracks.map(({ name, duration, isPlaying }, index) => (
+              <List.Item key={name}>
+                <DurationInfo isPlaying={isPlaying} duration={duration} />
+                <PlayStatus isPlaying={isPlaying} index={index} />
+                <Text
+                  isPlaying={isPlaying}
+                  activecolor="#42f46e"
+                  inactivecolor="grey"
+                >
+                  {name}
+                </Text>
+              </List.Item>))
+          }
+        </List>
+      </Segment>
+    );
+  }
+}

--- a/src/components/SpotifyPlayer/TrackPlayControl/AlbumPlayIcon.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/AlbumPlayIcon.js
@@ -16,15 +16,14 @@ const AlbumPlayIcon = ({
 }) => (
   <Dimmer.Dimmable
     dimmed={active}
-    inverted
     onMouseEnter={onMouseEnter}
     onMouseLeave={onMouseLeave}
   >
-    <Image src={albumImg} size="tiny" />
+    <Image src={albumImg} size="small" />
     <Dimmer active={active}>
       <Icon
         name={isPlaying ? 'pause circle outline' : 'play circle outline'}
-        size="big"
+        size="huge"
         onClick={togglePlay}
       />
     </Dimmer>
@@ -38,6 +37,6 @@ AlbumPlayIcon.propTypes = {
   isPlaying: PropTypes.bool.isRequired,
   togglePlay: PropTypes.func.isRequired,
   albumImg: PropTypes.string.isRequired,
-  onMouseEnter: PropTypes.bool.isRequired,
-  onMouseLeave: PropTypes.bool.isRequired,
+  onMouseEnter: PropTypes.func.isRequired,
+  onMouseLeave: PropTypes.func.isRequired,
 };

--- a/src/components/SpotifyPlayer/TrackPlayControl/AlbumPlayIcon.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/AlbumPlayIcon.js
@@ -33,10 +33,15 @@ const AlbumPlayIcon = ({
 export default AlbumPlayIcon;
 
 AlbumPlayIcon.propTypes = {
-  active: PropTypes.bool.isRequired,
-  isPlaying: PropTypes.bool.isRequired,
+  active: PropTypes.bool,
+  isPlaying: PropTypes.bool,
   togglePlay: PropTypes.func.isRequired,
   albumImg: PropTypes.string.isRequired,
   onMouseEnter: PropTypes.func.isRequired,
   onMouseLeave: PropTypes.func.isRequired,
+};
+
+AlbumPlayIcon.defaultProps = {
+  active: false,
+  isPlaying: false,
 };

--- a/src/components/SpotifyPlayer/TrackPlayControl/AlbumPlayIcon.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/AlbumPlayIcon.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Image,
+  Dimmer,
+  Icon,
+} from 'semantic-ui-react';
+
+const AlbumPlayIcon = ({
+  active,
+  isPlaying,
+  togglePlay,
+  albumImg,
+  onMouseEnter,
+  onMouseLeave,
+}) => (
+  <Dimmer.Dimmable
+    dimmed={active}
+    inverted
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
+  >
+    <Image src={albumImg} size="tiny" />
+    <Dimmer active={active}>
+      <Icon
+        name={isPlaying ? 'pause circle outline' : 'play circle outline'}
+        size="big"
+        onClick={togglePlay}
+      />
+    </Dimmer>
+  </Dimmer.Dimmable>
+);
+
+export default AlbumPlayIcon;
+
+AlbumPlayIcon.propTypes = {
+  active: PropTypes.bool.isRequired,
+  isPlaying: PropTypes.bool.isRequired,
+  togglePlay: PropTypes.func.isRequired,
+  albumImg: PropTypes.string.isRequired,
+  onMouseEnter: PropTypes.bool.isRequired,
+  onMouseLeave: PropTypes.bool.isRequired,
+};

--- a/src/components/SpotifyPlayer/TrackPlayControl/ProgressBar.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/ProgressBar.js
@@ -5,11 +5,12 @@ import styled from 'styled-components';
 const Progress = styled.div`
   width: ${({ percent }) => `${percent}`}%;
   height: 5px;
-  background: #a3a3a3;
+  background: #9b9da0;
+  border-radius: 4px;
 `;
 
 const Container = styled.div`
-  width: 200px;
+  width: 150px;
   height: 5px;
   background: #3f3f3f;
   border-radius: 4px;
@@ -28,4 +29,4 @@ export default class extends React.Component {
       </Container>
     );
   }
-};
+}

--- a/src/components/SpotifyPlayer/TrackPlayControl/ProgressBar.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/ProgressBar.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Progress = styled.div`
+  width: ${({ percent }) => `${percent}`}%;
+  height: 5px;
+  background: #a3a3a3;
+`;
+
+const Container = styled.div`
+  width: 200px;
+  height: 5px;
+  background: #3f3f3f;
+  border-radius: 4px;
+`;
+
+export default class extends React.Component {
+  static propTypes = {
+    percent: PropTypes.number.isRequired,
+  };
+
+  render() {
+    const { percent } = this.props;
+    return (
+      <Container>
+        <Progress percent={percent} />
+      </Container>
+    );
+  }
+};

--- a/src/components/SpotifyPlayer/TrackPlayControl/TrackInfo.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/TrackInfo.js
@@ -3,7 +3,7 @@ import PropType from 'prop-types';
 import { Header } from 'semantic-ui-react';
 
 const TrackInfo = ({ songName, artistsDisplayName }) => (
-  <Header inverted as="h5">
+  <Header inverted as="h4" style={{ paddingTop: 10 }}>
     {songName}
     <Header.Subheader inverted color="grey">
       {artistsDisplayName}

--- a/src/components/SpotifyPlayer/TrackPlayControl/TrackInfo.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/TrackInfo.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropType from 'prop-types';
+import { Header } from 'semantic-ui-react';
+
+const TrackInfo = ({ songName, artistsDisplayName }) => (
+  <Header inverted as="h5">
+    {songName}
+    <Header.Subheader inverted color="grey">
+      {artistsDisplayName}
+    </Header.Subheader>
+  </Header>
+);
+
+export default TrackInfo;
+
+TrackInfo.propTypes = {
+  songName: PropType.string.isRequired,
+  artistsDisplayName: PropType.string.isRequired,
+};

--- a/src/components/SpotifyPlayer/TrackPlayControl/index.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/index.js
@@ -41,7 +41,12 @@ export default class TrackPlayControl extends React.Component {
     onNext: PropTypes.func.isRequired,
     onPrevious: PropTypes.func.isRequired,
     positionMs: PropTypes.number.isRequired,
-    durationMs: PropTypes.number.isRequired,
+    durationMs: PropTypes.number,
+  };
+
+  static defaultProps = {
+    positionMs: 0,
+    durationMs: 0,
   };
 
   state = {

--- a/src/components/SpotifyPlayer/TrackPlayControl/index.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/index.js
@@ -1,18 +1,46 @@
 import React from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import {
-  Image,
-  Dimmer,
-  Icon,
-  Segment,
-  Header,
-} from 'semantic-ui-react';
+import { Icon } from 'semantic-ui-react';
+
+import AlbumPlayIcon from './AlbumPlayIcon';
+import ProgressBar from './ProgressBar';
+import TrackInfo from './TrackInfo';
+
+const FlexRow = styled.div`
+  display: flex;
+  align-items: stretch;
+  min-height: 5px;
+  background: ${({ color }) => (color ? `${color}` : 'transparent')};
+`;
+
+const FlewColumn = styled.div`
+  flex-direction: column;
+  min-height: 5px;
+  padding: 5px;
+`;
+
+const ControlButton = styled(Icon)`
+  color: ${({ active }) => (active ? 'white' : '#3f3f3f')};
+`;
 
 // TODO: add next song, previous song, current play status
 export default class TrackPlayControl extends React.Component {
   static propTypes = {
     trackInfo: PropTypes.object.isRequired,
     togglePlay: PropTypes.func.isRequired,
+    onNext: PropTypes.func.isRequired,
+    onPrevious: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    trackInfo: {
+      albumImg: 'https://i.scdn.co/image/7d9fada23c7044da31f8f687c84292885c180488',
+      songName: 'Lost Stars',
+      artistsDisplayName: 'Adam Levine',
+      isPlaying: true,
+    },
+    togglePlay: () => {},
   };
 
   state = {
@@ -28,31 +56,46 @@ export default class TrackPlayControl extends React.Component {
         isPlaying,
       },
       togglePlay,
+      onPrevious,
+      onNext,
     } = this.props;
-    const { active } = this.state;
+    const {
+      playButtonActive,
+      prevButtonActive,
+      nextButtonActive,
+    } = this.state;
+
     return (
-      <Segment inverted clearing>
-        <Dimmer.Dimmable
-          dimmed={active}
-          as={Image}
-          src={albumImg}
-          floated="left"
-          dimmer={{ active,
-            content: (
-              <Icon
-                name={isPlaying ? 'pause circle outline' : 'play circle outline'}
-                size="big"
-                onClick={togglePlay}
-              />
-            ) }}
-          onMouseEnter={() => this.setState({ active: true })}
-          onMouseLeave={() => this.setState({ active: false })}
+      <FlexRow color="#1b1c1d">
+        <AlbumPlayIcon
+          albumImg={albumImg}
+          isPlaying={isPlaying}
+          active={playButtonActive}
+          togglePlay={togglePlay}
+          onMouseEnter={() => this.setState({ playButtonActive: true })}
+          onMouseLeave={() => this.setState({ playButtonActive: false })}
         />
-        <Header inverted as="h5" floated="left">
-          {songName}
-          <Header.Subheader color="grey">{artistsDisplayName}</Header.Subheader>
-        </Header>
-      </Segment>
+        <FlewColumn>
+          <TrackInfo songName={songName} artistsDisplayName={artistsDisplayName} />
+          <FlexRow style={{ alignItems: 'center' }}>
+            <ControlButton
+              name="step backward"
+              onClick={onPrevious}
+              active={prevButtonActive}
+              onMouseEnter={() => this.setState({ prevButtonActive: true })}
+              onMouseLeave={() => this.setState({ prevButtonActive: false })}
+            />
+            <ProgressBar percent={20} />
+            <ControlButton
+              name="step forward"
+              active={nextButtonActive}
+              onClick={onNext}
+              onMouseEnter={() => this.setState({ nextButtonActive: true })}
+              onMouseLeave={() => this.setState({ nextButtonActive: false })}
+            />
+          </FlexRow>
+        </FlewColumn>
+      </FlexRow>
     );
   }
 }

--- a/src/components/SpotifyPlayer/TrackPlayControl/index.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import { Icon } from 'semantic-ui-react';
 
 import AlbumPlayIcon from './AlbumPlayIcon';
@@ -9,38 +10,38 @@ import TrackInfo from './TrackInfo';
 
 const FlexRow = styled.div`
   display: flex;
-  align-items: stretch;
   min-height: 5px;
   background: ${({ color }) => (color ? `${color}` : 'transparent')};
 `;
 
 const FlewColumn = styled.div`
+  display: flex;
   flex-direction: column;
+  justify-content: space-between;
   min-height: 5px;
   padding: 5px;
 `;
 
-const ControlButton = styled(Icon)`
-  color: ${({ active }) => (active ? 'white' : '#3f3f3f')};
+const TimeDisplay = styled.div`
+  color: #9b9da0;
+  font-size: 12px;
 `;
 
-// TODO: add next song, previous song, current play status
+const ControlButton = styled(Icon)`
+  color: ${({ active }) => (active ? 'white' : '#9b9da0')};
+`;
+
+/* eslint-disable no-underscore-dangle */
+const getTimeDisplay = time => moment(moment.duration(time)._data).format('mm:ss');
+
 export default class TrackPlayControl extends React.Component {
   static propTypes = {
     trackInfo: PropTypes.object.isRequired,
     togglePlay: PropTypes.func.isRequired,
     onNext: PropTypes.func.isRequired,
     onPrevious: PropTypes.func.isRequired,
-  };
-
-  static defaultProps = {
-    trackInfo: {
-      albumImg: 'https://i.scdn.co/image/7d9fada23c7044da31f8f687c84292885c180488',
-      songName: 'Lost Stars',
-      artistsDisplayName: 'Adam Levine',
-      isPlaying: true,
-    },
-    togglePlay: () => {},
+    positionMs: PropTypes.number.isRequired,
+    durationMs: PropTypes.number.isRequired,
   };
 
   state = {
@@ -54,6 +55,8 @@ export default class TrackPlayControl extends React.Component {
         songName,
         artistsDisplayName,
         isPlaying,
+        positionMs,
+        durationMs,
       },
       togglePlay,
       onPrevious,
@@ -64,6 +67,7 @@ export default class TrackPlayControl extends React.Component {
       prevButtonActive,
       nextButtonActive,
     } = this.state;
+    const percent = (positionMs) ? (positionMs * 100) / durationMs : 0;
 
     return (
       <FlexRow color="#1b1c1d">
@@ -76,23 +80,25 @@ export default class TrackPlayControl extends React.Component {
           onMouseLeave={() => this.setState({ playButtonActive: false })}
         />
         <FlewColumn>
-          <TrackInfo songName={songName} artistsDisplayName={artistsDisplayName} />
-          <FlexRow style={{ alignItems: 'center' }}>
+          <TrackInfo style={{ alignSelf: 'start' }} songName={songName} artistsDisplayName={artistsDisplayName} />
+          <FlexRow style={{ alignItems: 'center', alignSelf: 'flex-end' }}>
+            <TimeDisplay>{getTimeDisplay(positionMs)}</TimeDisplay>
             <ControlButton
               name="step backward"
               onClick={onPrevious}
-              active={prevButtonActive}
+              active={prevButtonActive ? 1 : 0}
               onMouseEnter={() => this.setState({ prevButtonActive: true })}
               onMouseLeave={() => this.setState({ prevButtonActive: false })}
             />
-            <ProgressBar percent={20} />
+            <ProgressBar style={{ paddingTop: 1 }} percent={percent} />
             <ControlButton
               name="step forward"
-              active={nextButtonActive}
+              active={nextButtonActive ? 1 : 0}
               onClick={onNext}
               onMouseEnter={() => this.setState({ nextButtonActive: true })}
               onMouseLeave={() => this.setState({ nextButtonActive: false })}
             />
+            <TimeDisplay>{getTimeDisplay(durationMs)}</TimeDisplay>
           </FlexRow>
         </FlewColumn>
       </FlexRow>

--- a/src/components/SpotifyPlayer/TrackPlayControl/index.js
+++ b/src/components/SpotifyPlayer/TrackPlayControl/index.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Image,
+  Dimmer,
+  Icon,
+  Segment,
+  Header,
+} from 'semantic-ui-react';
+
+// TODO: add next song, previous song, current play status
+export default class TrackPlayControl extends React.Component {
+  static propTypes = {
+    trackInfo: PropTypes.object.isRequired,
+    togglePlay: PropTypes.func.isRequired,
+  };
+
+  state = {
+    active: false,
+  };
+
+  render() {
+    const {
+      trackInfo: {
+        albumImg,
+        songName,
+        artistsDisplayName,
+        isPlaying,
+      },
+      togglePlay,
+    } = this.props;
+    const { active } = this.state;
+    return (
+      <Segment inverted clearing>
+        <Dimmer.Dimmable
+          dimmed={active}
+          as={Image}
+          src={albumImg}
+          floated="left"
+          dimmer={{ active,
+            content: (
+              <Icon
+                name={isPlaying ? 'pause circle outline' : 'play circle outline'}
+                size="big"
+                onClick={togglePlay}
+              />
+            ) }}
+          onMouseEnter={() => this.setState({ active: true })}
+          onMouseLeave={() => this.setState({ active: false })}
+        />
+        <Header inverted as="h5" floated="left">
+          {songName}
+          <Header.Subheader color="grey">{artistsDisplayName}</Header.Subheader>
+        </Header>
+      </Segment>
+    );
+  }
+}

--- a/src/components/SpotifyPlayer/index.js
+++ b/src/components/SpotifyPlayer/index.js
@@ -2,11 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import {
-  Loader,
-  Segment,
-  Card,
-} from 'semantic-ui-react';
+import { Segment } from 'semantic-ui-react';
 
 import {
   SpotifyActionCreators,
@@ -43,6 +39,16 @@ class SpotifyPlayer extends Component {
     togglePlayRequest();
   }
 
+  previousTrack = () => {
+    const { actions: { previousTrackRequest } } = this.props;
+    previousTrackRequest();
+  }
+
+  nextTrack = () => {
+    const { actions: { nextTrackRequest } } = this.props;
+    nextTrackRequest();
+  }
+
   render() {
     const {
       isLoading,
@@ -50,55 +56,30 @@ class SpotifyPlayer extends Component {
       tracks,
     } = this.props;
 
-    if (isLoading) {
-      return <Loader active inline="centered" />;
-    }
-
     return (
-      <Card>
-        <Segment.Group>
+      <Segment.Group compact style={{ width: 400 }}>
+        <Segment loading={isLoading} compact style={{ padding: 0 }}>
           <TrackPlayControl
             trackInfo={trackInfo}
             togglePlay={this.togglePlay}
+            onPrevious={this.previousTrack}
+            onNext={this.nextTrack}
           />
+        </Segment>
+        <Segment loading={isLoading} inverted compact>
           <TrackList tracks={tracks} />
-        </Segment.Group>
-      </Card>
+        </Segment>
+      </Segment.Group>
     );
   }
 }
 
-// TODO: get current track queue logic and remove test data
+// TODO: get current track queue logic and remove
 const trackTestData = [
   {
     duration: 267810,
     name: 'I really like you',
     isPlaying: true,
-  },
-  {
-    duration: 237810,
-    name: 'attention',
-    isPlaying: false,
-  },
-  {
-    duration: 237810,
-    name: 'attention',
-    isPlaying: false,
-  },
-  {
-    duration: 237810,
-    name: 'attention',
-    isPlaying: false,
-  },
-  {
-    duration: 237810,
-    name: 'attention',
-    isPlaying: false,
-  },
-  {
-    duration: 237810,
-    name: 'attention',
-    isPlaying: false,
   },
 ];
 

--- a/src/components/SpotifyPlayer/index.js
+++ b/src/components/SpotifyPlayer/index.js
@@ -8,6 +8,7 @@ import {
   SpotifyActionCreators,
   isLoadingPlayerSelector,
   currentTrackInfoSelector,
+  playListSelector,
 } from '../../redux/modules/spotify';
 
 import TrackList from './TrackList';
@@ -74,19 +75,10 @@ class SpotifyPlayer extends Component {
   }
 }
 
-// TODO: get current track queue logic and remove
-const trackTestData = [
-  {
-    duration: 267810,
-    name: 'I really like you',
-    isPlaying: true,
-  },
-];
-
 const mapStateToProps = state => ({
   isLoading: isLoadingPlayerSelector(state),
   trackInfo: currentTrackInfoSelector(state),
-  tracks: trackTestData,
+  tracks: playListSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/SpotifyPlayer/index.js
+++ b/src/components/SpotifyPlayer/index.js
@@ -4,20 +4,20 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import {
   Loader,
-  Image,
-  Icon,
   Segment,
   Card,
-  Header,
 } from 'semantic-ui-react';
 
 import {
   SpotifyActionCreators,
   isLoadingPlayerSelector,
   currentTrackInfoSelector,
-} from '../redux/modules/spotify';
+} from '../../redux/modules/spotify';
 
-class SongTrackCard extends Component {
+import TrackList from './TrackList';
+import TrackPlayControl from './TrackPlayControl';
+
+class SpotifyPlayer extends Component {
   static propTypes = {
     actions: PropTypes.shape({
       initPlayerRequest: PropTypes.func.isRequired,
@@ -30,6 +30,7 @@ class SongTrackCard extends Component {
       songName: PropTypes.string,
     }).isRequired,
     isLoading: PropTypes.bool.isRequired,
+    tracks: PropTypes.array.isRequired,
   }
 
   componentDidMount() {
@@ -43,41 +44,68 @@ class SongTrackCard extends Component {
   }
 
   render() {
-    const { isLoading } = this.props;
+    const {
+      isLoading,
+      trackInfo,
+      tracks,
+    } = this.props;
 
     if (isLoading) {
       return <Loader active inline="centered" />;
     }
 
-    const {
-      trackInfo: {
-        isPlaying,
-        albumImg,
-        artistsDisplayName,
-        songName,
-      },
-    } = this.props;
-
     return (
-      <Card centered>
-        <Segment inverted textAlign="center">
-          <Image src={albumImg} />
-          <Header as="h3">{songName}</Header>
-          <Header as="h4" inverted color="grey">{artistsDisplayName}</Header>
-          <Icon
-            name={isPlaying ? 'pause circle outline' : 'play circle outline'}
-            size="big"
-            onClick={this.togglePlay}
+      <Card>
+        <Segment.Group>
+          <TrackPlayControl
+            trackInfo={trackInfo}
+            togglePlay={this.togglePlay}
           />
-        </Segment>
+          <TrackList tracks={tracks} />
+        </Segment.Group>
       </Card>
     );
   }
 }
 
+// TODO: get current track queue logic and remove test data
+const trackTestData = [
+  {
+    duration: 267810,
+    name: 'I really like you',
+    isPlaying: true,
+  },
+  {
+    duration: 237810,
+    name: 'attention',
+    isPlaying: false,
+  },
+  {
+    duration: 237810,
+    name: 'attention',
+    isPlaying: false,
+  },
+  {
+    duration: 237810,
+    name: 'attention',
+    isPlaying: false,
+  },
+  {
+    duration: 237810,
+    name: 'attention',
+    isPlaying: false,
+  },
+  {
+    duration: 237810,
+    name: 'attention',
+    isPlaying: false,
+  },
+];
+
 const mapStateToProps = state => ({
   isLoading: isLoadingPlayerSelector(state),
   trackInfo: currentTrackInfoSelector(state),
+  tracks: trackTestData,
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -89,4 +117,4 @@ const mapDispatchToProps = dispatch => ({
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(SongTrackCard);
+)(SpotifyPlayer);

--- a/src/redux/modules/spotify.js
+++ b/src/redux/modules/spotify.js
@@ -134,7 +134,7 @@ export const currentTrackInfoSelector = createSelector([
   const artistsDisplayName = artists.map(({ name }) => name).join(', ');
   return {
     songName,
-    albumImg: albumImgs[0].url,
+    albumImg: albumImgs[1].url,
     artistsDisplayName,
     isPlaying: !paused,
   };

--- a/src/redux/modules/spotify.js
+++ b/src/redux/modules/spotify.js
@@ -20,12 +20,16 @@ const INIT_PLAYER = actionTypesCreator('INIT_PLAYER');
 const PLAY = actionTypesCreator('PLAY');
 const TOGGLE_PLAY = actionTypesCreator('TOGGLE_PLAY');
 const GET_CURRENT_PLAYER_STATE = actionTypesCreator('GET_CURRENT_PLAYER_STATE');
+const PREVIOUS_TRACK = actionTypesCreator('PREVIOUS_TRACK');
+const NEXT_TRACK = actionTypesCreator('NEXT_TRACK');
 
 export const SpotifyActionCreators = createActions(
   ...Object.values(INIT_PLAYER),
   ...Object.values(PLAY),
   ...Object.values(TOGGLE_PLAY),
   ...Object.values(GET_CURRENT_PLAYER_STATE),
+  ...Object.values(PREVIOUS_TRACK),
+  ...Object.values(NEXT_TRACK),
 );
 
 
@@ -43,16 +47,22 @@ function* getCurrentPlayerState() {
 
 function getCurrentPlayerStateChannel() {
   return eventChannel((emit) => {
-    SpotifyService.player.on('player_state_changed', emit);
+    // // NOTE: synchronize player state for every 1s.
+    setInterval(() => {
+      emit(GET_CURRENT_PLAYER_STATE.REQUEST);
+    }, 1000);
+    SpotifyService.player.on('player_state_changed', () => emit(GET_CURRENT_PLAYER_STATE.REQUEST));
     return () => {};
   });
 }
 
 function* watchPlayerStateChange() {
-  const changeChaneel = yield call(getCurrentPlayerStateChannel);
+  const changeChannel = yield call(getCurrentPlayerStateChannel);
   while (true) {
-    yield take(changeChaneel);
-    yield call(getCurrentPlayerState);
+    const action = yield take(changeChannel);
+    if (action === GET_CURRENT_PLAYER_STATE.REQUEST) {
+      yield call(getCurrentPlayerState);
+    }
   }
 }
 
@@ -89,7 +99,7 @@ function* play({ payload: { spotifyUri, positionMs } }) {
 
 function* togglePlay() {
   try {
-    yield SpotifyService.player.togglePlay();
+    yield call(SpotifyService.togglePlay);
     yield put(SpotifyActionCreators.togglePlaySuccess());
   } catch (e) {
     console.log(e);
@@ -97,10 +107,32 @@ function* togglePlay() {
   }
 }
 
+function* previousTrack() {
+  try {
+    yield call(SpotifyService.previousTrack);
+    yield put(SpotifyActionCreators.previousTrackSuccess());
+  } catch (e) {
+    console.log(e);
+    yield put(SpotifyActionCreators.previousTrackFailure(e));
+  }
+}
+
+function* nextTrack() {
+  try {
+    yield call(SpotifyService.nextTrack);
+    yield put(SpotifyActionCreators.nextTrackSuccess());
+  } catch (e) {
+    console.log(e);
+    yield put(SpotifyActionCreators.nextTrackFailure(e));
+  }
+}
+
 export const SpotifySagas = [
   takeLatest(INIT_PLAYER.REQUEST, initPlayer),
   takeLatest(PLAY.REQUEST, play),
   takeLatest(TOGGLE_PLAY.REQUEST, togglePlay),
+  takeLatest(PREVIOUS_TRACK.REQUEST, previousTrack),
+  takeLatest(NEXT_TRACK.REQUEST, nextTrack),
 ];
 
 // NOTE: selectors
@@ -130,13 +162,17 @@ export const currentTrackInfoSelector = createSelector([
       },
     },
     paused,
+    position: positionMs,
+    duration: durationMs,
   } = playerState;
   const artistsDisplayName = artists.map(({ name }) => name).join(', ');
   return {
     songName,
-    albumImg: albumImgs[1].url,
+    albumImg: albumImgs[0].url,
     artistsDisplayName,
     isPlaying: !paused,
+    positionMs: positionMs || 0,
+    durationMs: durationMs || 0,
   };
 });
 

--- a/src/redux/modules/spotify.js
+++ b/src/redux/modules/spotify.js
@@ -176,6 +176,10 @@ export const currentTrackInfoSelector = createSelector([
   };
 });
 
+// TODO: currently playlist is not added in reducer, need to refactor this logic
+export const playListSelector = createSelector(currentTrackInfoSelector,
+  trackInfo => [trackInfo]);
+
 // NOTE: reducer
 const initialState = {
   isLoading: false,

--- a/src/services/SpotifyService.js
+++ b/src/services/SpotifyService.js
@@ -101,6 +101,12 @@ class SpotifyService {
     }
     return result;
   };
+
+  togglePlay = () => this.player.togglePlay();
+
+  previousTrack = () => this.player.previousTrack();
+
+  nextTrack = () => this.player.nextTrack();
 }
 
 export default new SpotifyService();


### PR DESCRIPTION
Feature:
- Spotify player refactor
- Spotify player play list layout

TODOs:
- add songs
- fetch play list (currently only able to get currenly play song)

Current Player Layout:
<img width="404" alt="screen shot 2018-08-18 at 7 54 09 pm" src="https://user-images.githubusercontent.com/24989784/44304950-94786800-a320-11e8-907d-934068048aa9.png">

